### PR TITLE
Add pagination support to posts, replies and users endpoints

### DIFF
--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -1,8 +1,15 @@
 import { getAllPosts, createPost } from '../models/postModel.js';
 
-export const getPosts = async (req, res) => {
-    const posts = await getAllPosts();
-    res.json(posts);
+export const getPosts = async (req, res, next) => {
+    try {
+        const limit = parseInt(req.query.limit) || 10;
+        const offset = parseInt(req.query.offset) || 0;
+
+        const posts = await getAllPosts(limit, offset);
+        res.json(posts);
+    } catch(err) {
+        next(err);
+    }
 };
 
 export const addPost = async (req, res, next) => {

--- a/src/controllers/replyController.js
+++ b/src/controllers/replyController.js
@@ -4,7 +4,9 @@ import { getPostById } from '../models/postModel.js';
 export const getReplies = async (req, res, next) => {
     try {
         const { postId } = req.params;
-        const replies = await getRepliesByPostId(postId);
+        const limit = parseInt(req.query.limit) || 10;
+        const offset = parseInt(req.query.offset) || 0;
+        const replies = await getRepliesByPostId(postId, limit, offset);
         res.json(replies);
     } catch(err) {
         next(err);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,8 +1,15 @@
 import { getAllUsers, createUser } from '../models/userModel.js';
 
-export const getUsers = async (req, res) => {
-    const users = await getAllUsers();
-    res.json(users);
+export const getUsers = async (req, res, next) => {
+    try {
+        const limit = parseInt(req.query.limit) || 10;
+        const offset = parseInt(req.query.offset) || 0;
+    
+        const users = await getAllUsers(limit, offset);
+        res.json(users);
+    } catch(err) {
+        next(err);
+    }
 };
 
 export const addUser = async (req, res, next) => {

--- a/src/models/postModel.js
+++ b/src/models/postModel.js
@@ -1,7 +1,10 @@
 import pool from '../config/db.js';
 
-export const getAllPosts = async () => {
-    const result = await pool.query('SELECT * FROM posts ORDER BY created_at DESC');
+export const getAllPosts = async (limit = 10, offset = 0) => {
+    const result = await pool.query(
+        'SELECT * FROM posts ORDER BY created_at DESC LIMIT $1 OFFSET $2',
+        [limit, offset]
+    );
     return result.rows;
 };
 

--- a/src/models/replyModel.js
+++ b/src/models/replyModel.js
@@ -1,9 +1,9 @@
 import pool from '../config/db.js';
 
-export const getRepliesByPostId = async (postId) => {
+export const getRepliesByPostId = async (postId, limit = 10, offset = 0) => {
     const result = await pool.query(
-        'SELECT * FROM replies WHERE post_id = $1 ORDER BY created_at DESC',
-        [postId]
+        'SELECT * FROM replies WHERE post_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3',
+        [postId, limit, offset]
     );
     return result.rows;
 };

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -1,7 +1,10 @@
 import pool from '../config/db.js';
 
-export const getAllUsers = async () => {
-    const result = await pool.query('SELECT * FROM users ORDER BY created_at DESC');
+export const getAllUsers = async (limit = 10, offset = 0) => {
+    const result = await pool.query(
+        'SELECT * FROM users ORDER BY created_at DESC LIMIT $1 OFFSET $2',
+        [limit, offset]
+    );
     return result.rows;
 };
 


### PR DESCRIPTION
## Description

This PR adds **pagination support** for the following endpoints:
- `GET /api/posts`
- `GET /api/posts/:postId/replies`
- `GET /api/users`

Clients can now pass `limit` and `offset` as query parameters to control the number of records returned. 

- Added `limit` and `offset` handling in:
  - `getPosts` controller
  - `getReplies` controller
  - `getUsers` controller
- Updated model functions (`getAllPosts`, `getRepliesByPostId`, `getAllUsers`) to support pagination. 